### PR TITLE
Add hardened .npmrc for supply-chain security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# Supply-chain hardening directives
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+engine-strict=true
+legacy-peer-deps=false
+audit-level=high


### PR DESCRIPTION
Adds a hardened `.npmrc` enforcing npm supply-chain best practices:

```ini
ignore-scripts=true
strict-ssl=true
save-exact=true
engine-strict=true
legacy-peer-deps=false
audit-level=high
```

Notes:
- `ignore-scripts=true` skips Cypress's postinstall binary download. Cloud runs via `browserstack-cypress` are unaffected; for local Cypress runs, execute `npx cypress install` once after `npm install`.
- Verified: `npm ci` against the committed package-lock.json on Node 16, 18, and 20 — lockfile unchanged; sample test run verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
